### PR TITLE
Refactor in order to support return url

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,11 @@ class BankIDLoginAction(bankid_sdk.AuthAction):
             raise bankid_sdk.FinalizeFailed(detail="No registered user found")
 
         login(request, user)
+
+    # Optional method to define to build a custom return url
+    # defaults to current host origin with url fragment #nonce={transaction_id}
+    def build_return_url(self, request: Any, transaction_id: str) -> str | None:
+        return f"https://some-custom-return-url.com/#nonce={transaction_id}"
 ```
 
 The above `authenticate` call from Django requires [writing a custom

--- a/src/bankid_sdk/_actions.py
+++ b/src/bankid_sdk/_actions.py
@@ -78,9 +78,7 @@ class Action(ABC):
         ...
 
     def build_return_url(self, request: Any, transaction_id: str) -> str | None:
-        # build return url from request origin
-        base = request.META.get("HTTP_ORIGIN")
-        return f"{base}#nonce={transaction_id}"
+        return None
 
 
 class AuthAction(Action):

--- a/src/bankid_sdk/_actions.py
+++ b/src/bankid_sdk/_actions.py
@@ -77,6 +77,11 @@ class Action(ABC):
     ) -> None:
         ...
 
+    def build_return_url(self, request: Any, transaction_id: str) -> str | None:
+        # build return url from request origin
+        base = request.META.get("HTTP_ORIGIN")
+        return f"{base}#nonce={transaction_id}"
+
 
 class AuthAction(Action):
     @abstractmethod

--- a/src/bankid_sdk/_auth.py
+++ b/src/bankid_sdk/_auth.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import uuid
 from base64 import b64encode
 from typing import TYPE_CHECKING, Any, Literal, NamedTuple
 
@@ -32,6 +33,7 @@ def build_auth_request(
     user_visible_data: str | None = None,
     user_non_visible_data: str | None = None,
     user_visible_data_format: Literal["simpleMarkdownV1"] | None = None,
+    return_url: str | None = None,
 ) -> dict[str, Any]:
     data: dict[str, Any] = {"endUserIp": end_user_ip}
     for key, option in [
@@ -39,6 +41,7 @@ def build_auth_request(
         ("userVisibleData", encode_user_data(user_visible_data)),
         ("userNonVisibleData", encode_user_data(user_non_visible_data)),
         ("userVisibleDataFormat", user_visible_data_format),
+        ("returnUrl", return_url),
     ]:
         if option is not None:
             data[key] = option
@@ -57,21 +60,29 @@ def init_auth(
     user_data, transaction_context = action().initialize(
         order_request.request, order_request.context
     )
+    transaction_id = TransactionID(str(uuid.uuid4()))
+    return_url = action().build_return_url(
+        order_request.request, transaction_id=transaction_id
+    )
     order_response = client.auth(
         end_user_ip=order_request.end_user_ip,
         requirement=order_request.requirement,
         user_visible_data=user_data.visible,
         user_non_visible_data=user_data.non_visible,
         user_visible_data_format=user_data.visible_format,
+        return_url=return_url,
+    )
+
+    config.STORAGE.save(
+        Transaction(
+            transaction_id=transaction_id,
+            order_response=order_response,
+            operation="auth",
+            action_name=action.name,
+            context=transaction_context,
+        )
     )
     return AuthOrder(
-        transaction_id=config.STORAGE.save(
-            Transaction(
-                order_response=order_response,
-                operation="auth",
-                action_name=action.name,
-                context=transaction_context,
-            )
-        ),
+        transaction_id=transaction_id,
         auto_start_token=order_response.auto_start_token,
     )

--- a/src/bankid_sdk/_client.py
+++ b/src/bankid_sdk/_client.py
@@ -58,20 +58,20 @@ _Client = TypeVar("_Client", bound=GetExcHooks)
 
 @overload
 def handle_exception(
-    method: Callable[Concatenate[_Client, P], Awaitable[T]]
+    method: Callable[Concatenate[_Client, P], Awaitable[T]],
 ) -> Callable[Concatenate[_Client, P], Awaitable[T]]:
     ...
 
 
 @overload
 def handle_exception(
-    method: Callable[Concatenate[_Client, P], T]
+    method: Callable[Concatenate[_Client, P], T],
 ) -> Callable[Concatenate[_Client, P], T]:
     ...
 
 
 def handle_exception(
-    method: Callable[Concatenate[_Client, P], T]
+    method: Callable[Concatenate[_Client, P], T],
 ) -> Callable[Concatenate[_Client, P], Awaitable[T] | T]:
     """
     Activates a client's currently configured exception hook/handling chain.
@@ -139,6 +139,7 @@ class AsyncV60(V60Base):
         user_visible_data: str | None = None,
         user_non_visible_data: str | None = None,
         user_visible_data_format: Literal["simpleMarkdownV1"] | None = None,
+        return_url: str | None = None,
     ) -> OrderResponse:
         data = build_auth_request(
             end_user_ip,
@@ -146,6 +147,7 @@ class AsyncV60(V60Base):
             user_visible_data,
             user_non_visible_data,
             user_visible_data_format,
+            return_url=return_url,
         )
         response = await self.client.post(
             self.build_path("/auth"), json=data, headers=self.headers
@@ -175,11 +177,14 @@ class AsyncV60(V60Base):
 
     @handle_exception
     async def collect(
-        self, order_ref: OrderRef
+        self, order_ref: OrderRef, return_url: str | None = None
     ) -> PendingCollect | CompleteCollect | FailedCollect:
+        data: dict[str, Any] = {"orderRef": order_ref}
+        if return_url is not None:
+            data["returnUrl"] = return_url
         response = await self.client.post(
             self.build_path("/collect"),
-            json={"orderRef": order_ref},
+            json=data,
             headers=self.headers,
         )
         return process_collect_response(response)
@@ -209,6 +214,7 @@ class SyncV60(V60Base):
         user_visible_data: str | None = None,
         user_non_visible_data: str | None = None,
         user_visible_data_format: Literal["simpleMarkdownV1"] | None = None,
+        return_url: str | None = None,
     ) -> OrderResponse:
         data = build_auth_request(
             end_user_ip,
@@ -216,6 +222,7 @@ class SyncV60(V60Base):
             user_visible_data,
             user_non_visible_data,
             user_visible_data_format,
+            return_url=return_url,
         )
         response = self.client.post(
             self.build_path("/auth"), json=data, headers=self.headers
@@ -245,11 +252,14 @@ class SyncV60(V60Base):
 
     @handle_exception
     def collect(
-        self, order_ref: OrderRef
+        self, order_ref: OrderRef, return_url: str | None = None
     ) -> PendingCollect | CompleteCollect | FailedCollect:
+        data: dict[str, Any] = {"orderRef": order_ref}
+        if return_url is not None:
+            data["returnUrl"] = return_url
         response = self.client.post(
             self.build_path("/collect"),
-            json={"orderRef": order_ref},
+            json=data,
             headers=self.headers,
         )
         return process_collect_response(response)

--- a/src/bankid_sdk/_order.py
+++ b/src/bankid_sdk/_order.py
@@ -10,7 +10,7 @@ import httpx
 from typing_extensions import Self
 
 from ._requirement import Requirement
-from .typing import OrderRef
+from .typing import OrderRef, TransactionID
 
 
 class OrderRequest(NamedTuple):
@@ -42,6 +42,7 @@ def process_order_response(response: httpx.Response) -> OrderResponse:
 
 
 class SerializedTransaction(TypedDict):
+    transaction_id: str
     order_ref: OrderRef
     auto_start_token: str
     qr_start_token: str
@@ -54,6 +55,7 @@ class SerializedTransaction(TypedDict):
 
 @dataclass(frozen=True)
 class Transaction:
+    transaction_id: TransactionID
     order_response: OrderResponse
     operation: Literal["auth", "sign"]
     action_name: str
@@ -62,6 +64,7 @@ class Transaction:
     @classmethod
     def from_dict(cls, obj: dict[str, Any], /) -> Self:
         return cls(
+            transaction_id=obj["transaction_id"],
             order_response=OrderResponse(
                 order_ref=OrderRef(str(obj["order_ref"])),
                 auto_start_token=str(obj["auto_start_token"]),
@@ -76,6 +79,7 @@ class Transaction:
 
     def as_dict(self) -> SerializedTransaction:
         return SerializedTransaction(
+            transaction_id=self.transaction_id,
             order_ref=self.order_response.order_ref,
             auto_start_token=self.order_response.auto_start_token,
             qr_start_token=self.order_response.qr_start_token,

--- a/src/bankid_sdk/_storage.py
+++ b/src/bankid_sdk/_storage.py
@@ -2,14 +2,13 @@ from __future__ import annotations
 
 from contextlib import suppress
 from typing import Final, Protocol
-from uuid import uuid4
 
 from ._order import Transaction
 from .typing import TransactionID
 
 
 class Storage(Protocol):
-    def save(self, obj: Transaction, /) -> TransactionID:
+    def save(self, obj: Transaction, /) -> None:
         ...
 
     def load(self, key: TransactionID, /) -> Transaction | None:
@@ -26,10 +25,8 @@ class MemoryStorage:
     def __init__(self) -> None:
         self.content = dict[TransactionID, Transaction]()
 
-    def save(self, obj: Transaction, /) -> TransactionID:
-        transaction_id = TransactionID(str(uuid4()))
-        self.content[transaction_id] = obj
-        return transaction_id
+    def save(self, obj: Transaction, /) -> None:
+        self.content[obj.transaction_id] = obj
 
     def load(self, key: TransactionID, /) -> Transaction | None:
         obj = self.content.get(key, self.NO_VALUE)

--- a/src/bankid_sdk/contrib/django/storage.py
+++ b/src/bankid_sdk/contrib/django/storage.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from uuid import uuid4
-
 from django.core.cache import cache
 
 import bankid_sdk
@@ -10,11 +8,9 @@ import bankid_sdk
 class CacheStorage:
     __slots__ = ()
 
-    def save(self, obj: bankid_sdk.Transaction, /) -> bankid_sdk.TransactionID:
-        transaction_id = bankid_sdk.TransactionID(str(uuid4()))
+    def save(self, obj: bankid_sdk.Transaction, /) -> None:
         # Kept in cache for 15min
-        cache.set(key=transaction_id, value=obj.as_dict(), timeout=60 * 15)
-        return transaction_id
+        cache.set(key=obj.transaction_id, value=obj.as_dict(), timeout=60 * 15)
 
     def load(self, key: bankid_sdk.TransactionID, /) -> bankid_sdk.Transaction | None:
         obj = cache.get(key)

--- a/src/bankid_sdk/contrib/django/transaction.py
+++ b/src/bankid_sdk/contrib/django/transaction.py
@@ -1,29 +1,2 @@
-from __future__ import annotations
-
-from contextlib import suppress
-from datetime import timedelta
-from typing import Final
-
-from django.core import signing
-
-import bankid_sdk
-
-_transaction_signer: Final = signing.TimestampSigner(
-    salt="bankid_sdk.contrib.django.transaction"
-)
-
-
-def envelop(value: bankid_sdk.TransactionID, /) -> str:
-    return _transaction_signer.sign_object(value)
-
-
-def verify_envelope(value: str, /) -> bankid_sdk.TransactionID | None:
-    with suppress(signing.BadSignature):
-        return bankid_sdk.TransactionID(
-            _transaction_signer.unsign_object(value, max_age=timedelta(minutes=5))
-        )
-    return None
-
-
 def mask_last_four(personal_number: str) -> str:
     return personal_number[:-4] + "XXXX"

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -2,10 +2,12 @@ from datetime import datetime, timezone
 from uuid import uuid4
 
 import bankid_sdk
+from bankid_sdk.typing import TransactionID
 
 
 def TransactionFactory() -> bankid_sdk.Transaction:
     return bankid_sdk.Transaction(
+        transaction_id=TransactionID(str(uuid4())),
         order_response=bankid_sdk.OrderResponse(
             order_ref=bankid_sdk.OrderRef(str(uuid4())),
             auto_start_token=str(uuid4()),

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,6 +1,14 @@
 import bankid_sdk
+from tests.factories import TransactionFactory
 
 
 class TestMemoryStorage:
     def test_load_returns_none_for_unknown_key(self) -> None:
         assert bankid_sdk.MemoryStorage().load(bankid_sdk.TransactionID("ID")) is None
+
+    def test_can_delete_transaction(self) -> None:
+        transaction = TransactionFactory()
+        storage = bankid_sdk.MemoryStorage()
+        storage.save(transaction)
+        storage.delete(transaction.transaction_id)
+        assert storage.load(transaction.transaction_id) is None

--- a/tests/v60/test_auth.py
+++ b/tests/v60/test_auth.py
@@ -43,6 +43,7 @@ def send_minimal_auth_request_context() -> (
             "autoStartToken": "7c40b5c9-fa74-49cf-b98c-bfe651f9a7c6",
             "qrStartToken": "67df3917-fa0d-44e5-b327-edcc928297f8",
             "qrStartSecret": "d28db9a7-4cde-429e-a983-359be676944c",
+            "returnUrl": "https://example.com",
         },
     )
     response = yield {"end_user_ip": "127.0.0.1"}

--- a/tests/v60/test_check.py
+++ b/tests/v60/test_check.py
@@ -1,17 +1,17 @@
 import pytest
 
 import bankid_sdk
+from bankid_sdk._collect import ActionNotFoundError
 from tests.factories import TransactionFactory
 
 pytestmark = pytest.mark.usefixtures("mock_bankid")
 
 
-def test_handles_completion_when_action_is_unknown(
+def test_action_not_found_error_is_raised_when_action_is_unknown(
     sync_v60: bankid_sdk.SyncV60, valid_collect: bankid_sdk.OrderRef
 ) -> None:
     bankid_sdk.configure(storage=bankid_sdk.MemoryStorage(), actions=[])
     transaction = TransactionFactory()
-    transaction_id = bankid_sdk.config.STORAGE.save(transaction)
-    result, qr_code = bankid_sdk.check(sync_v60, transaction_id, None)
-    assert isinstance(result, bankid_sdk.CompleteCollect)
-    assert qr_code is None
+    bankid_sdk.config.STORAGE.save(transaction)
+    with pytest.raises(ActionNotFoundError):
+        bankid_sdk.check(sync_v60, transaction.transaction_id, None)

--- a/tests/v60/test_error_handling.py
+++ b/tests/v60/test_error_handling.py
@@ -21,6 +21,7 @@ from bankid_sdk.errors import (
     UnknownError,
     UnsupportedMediaType,
 )
+from bankid_sdk.typing import OrderRef
 from tests.mocks import bankid_mock
 
 pytestmark = pytest.mark.usefixtures("mock_bankid")
@@ -39,10 +40,10 @@ def default_routing(
             async_v60.sign, end_user_ip="127.0.0.1", user_visible_data="visible data"
         )
     elif request.param == "collect":
-        call = partial(async_v60.collect, order_ref="ref")
+        call = partial(async_v60.collect, order_ref=OrderRef("ref"))
     else:
         assert request.param == "cancel"
-        call = partial(async_v60.cancel, order_ref="ref")
+        call = partial(async_v60.cancel, order_ref=OrderRef("ref"))
 
     return bankid_mock[request.param], call
 


### PR DESCRIPTION
In order to support returnUrl as specified in BankID docs we now expose our transaction_id to be used as nonce in the returnUrl. See https://developers.bankid.com/getting-started/frontend/return-url

- Remove signing/unsigning of transaction_id I seen no reason for validating the 5 minute lifetime of auth orders. BankID already handles this on their side. Our transaction_id also isn't secret for the user logging in, it's our reference to the BankID auth order.